### PR TITLE
Automatic dependency updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.3] - 2026-01-01
+### Changed
+- Updated min sdk version to ^3.10.0
+- Updated dependencies
+
 ## [1.1.2] - 2025-10-11
 ### Changed
 - Updated min dart sdk to 3.9.0
@@ -74,6 +79,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial pre-release
 
+[1.1.3]: https://github.com/Skycoder42/dynssh/compare/v1.1.2...v1.1.3
 [1.1.2]: https://github.com/Skycoder42/dynssh/compare/v1.1.1...v1.1.2
 [1.1.1]: https://github.com/Skycoder42/dynssh/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/Skycoder42/dynssh/compare/v1.0.9...v1.1.0

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,5 +1,6 @@
 include: package:dart_test_tools/strict.yaml
-
+plugins:
+  dart_test_tools: ^7.0.1
 analyzer:
   exclude:
     - "**.freezed.dart"

--- a/lib/src/config/config.dart
+++ b/lib/src/config/config.dart
@@ -42,7 +42,7 @@ class Config {
     return apiKeyConfig.apiKeys[host];
   }
 
-  // ignore: use_setters_to_change_properties
+  // ignore: use_setters_to_change_properties for initializer
   void initialize(Options cliOptions) {
     _cliOptions = cliOptions;
   }

--- a/lib/src/dynssh/return_code.dart
+++ b/lib/src/dynssh/return_code.dart
@@ -12,6 +12,6 @@ enum ReturnCode {
   final String raw;
   final bool isSuccess;
 
-  // ignore: avoid_positional_boolean_parameters
+  // ignore: avoid_positional_boolean_parameters for enums
   const ReturnCode(this.raw, this.isSuccess);
 }

--- a/lib/src/server/dynssh_api.dart
+++ b/lib/src/server/dynssh_api.dart
@@ -7,7 +7,7 @@ import 'endpoints/dynssh_endpoint.dart';
 part 'dynssh_api.g.dart';
 
 @ShelfApi([DynsshEndpoint])
-// ignore: unused_element
+// ignore: unused_element for api generation
 class _DynsshApi {}
 
 class DynsshApiMirror extends DynsshApi {}

--- a/lib/src/server/http_server.dart
+++ b/lib/src/server/http_server.dart
@@ -74,7 +74,7 @@ class HttpServer {
       (next) => (request) async {
         try {
           return await next(request);
-          // ignore: avoid_catches_without_on_clauses
+          // ignore: avoid_catches_without_on_clauses for forwarding
         } catch (e, s) {
           final buffer = StringBuffer()
             ..writeln(e)
@@ -88,6 +88,7 @@ class HttpServer {
 extension on Pipeline {
   Pipeline debugAddMiddleware(Middleware middleware) {
     var result = this;
+    // ignore: prefer_asserts_with_message to add debug middleware
     assert(() {
       result = addMiddleware(middleware);
       return true;

--- a/lib/src/server/middlewares/dynssh_return_code_middleware.dart
+++ b/lib/src/server/middlewares/dynssh_return_code_middleware.dart
@@ -51,7 +51,7 @@ class DynsshReturnCodeMiddleware {
         >= 500 => ReturnCode.$911.toResponse(),
         _ => response,
       };
-      // ignore: avoid_catches_without_on_clauses
+      // ignore: avoid_catches_without_on_clauses to hide errors from client
     } catch (e, s) {
       _logger.severe('Internal server error', e, s);
       return ReturnCode.$911.toResponse();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,10 +1,10 @@
 name: dynssh
 description: A small server utility to dynamically update the SSH configuration for a remote host with dynamic IPs.
-version: 1.1.2
+version: 1.1.3
 publish_to: none
 
 environment:
-  sdk: ^3.9.0
+  sdk: ^3.10.0
 
 platforms:
   linux:
@@ -25,22 +25,22 @@ dependencies:
   riverpod: ^3.0.3
   riverpod_annotation: ^3.0.3
   shelf: ^1.4.2
-  shelf_api: ^1.4.0
+  shelf_api: ^1.4.1
   synchronized: ^3.4.0
 
 dev_dependencies:
   build_cli: ^2.2.8
-  build_runner: ^2.9.0
+  build_runner: ^2.10.4
   custom_lint: ^0.8.1
-  dart_pre_commit: ^6.0.0
-  dart_test_tools: ^6.2.3+1
+  dart_pre_commit: ^6.1.0
+  dart_test_tools: ^7.0.1
   freezed: ^3.2.3
-  http: ^1.5.0
-  json_serializable: ^6.11.1
+  http: ^1.6.0
+  json_serializable: ^6.11.2
   mocktail: ^1.0.4
   riverpod_generator: ^3.0.3
   riverpod_lint: ^3.0.3
-  shelf_api_builder: ^1.3.0
+  shelf_api_builder: ^1.3.1
   test: ^1.26.3
 
 dart_pre_commit:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,7 +31,6 @@ dependencies:
 dev_dependencies:
   build_cli: ^2.2.8
   build_runner: ^2.10.4
-  custom_lint: ^0.8.1
   dart_pre_commit: ^6.1.0
   dart_test_tools: ^7.0.1
   freezed: ^3.2.3
@@ -41,7 +40,7 @@ dev_dependencies:
   riverpod_generator: ^3.0.3
   riverpod_lint: ^3.0.3
   shelf_api_builder: ^1.3.1
-  test: ^1.26.3
+  test: ^1.28.0
 
 dart_pre_commit:
   flutter-compat: false

--- a/test/integration/dynssh_docker_test.dart
+++ b/test/integration/dynssh_docker_test.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: avoid_print
+// ignore_for_file: avoid_print for testing
 
 @TestOn('linux')
 library;
@@ -64,7 +64,7 @@ final class _DynsshDockerTestCase extends DynsshTestCase {
 
         return port;
 
-        // ignore: avoid_catches_without_on_clauses
+        // ignore: avoid_catches_without_on_clauses for testing
       } catch (e) {
         await Future<void>.delayed(const Duration(seconds: 1));
         continue;

--- a/test/integration/dynssh_test_case.dart
+++ b/test/integration/dynssh_test_case.dart
@@ -20,16 +20,16 @@ abstract base class DynsshTestCase {
     const testApiKey =
         'j8efu893pu8fsjifskjfo983u0f09ufe0suf093uf90uwu9eusfkdsf';
     const testAuthHeader =
-        // ignore: lines_longer_than_80_chars
+        // ignore: lines_longer_than_80_chars for testing
         'Basic dGVzdC5keW5zc2guc2t5Y29kZXI0Mi5kZTpqOGVmdTg5M3B1OGZzamlmc2tqZm85ODN1MGYwOXVmZTBzdWYwOTN1ZjkwdXd1OWV1c2ZrZHNm';
     const testForbiddenAuthHeader =
-        // ignore: lines_longer_than_80_chars
+        // ignore: lines_longer_than_80_chars for testing
         'Basic Zm9yYmlkZGVuLnRlc3QuZHluc3NoLnNreWNvZGVyNDIuZGU6ajhlZnU4OTNwdThmc2ppZnNramZvOTgzdTBmMDl1ZmUwc3VmMDkzdWY5MHV3dTlldXNma2RzZg==';
     const testUnknownAuthHeader =
-        // ignore: lines_longer_than_80_chars
+        // ignore: lines_longer_than_80_chars for testing
         'Basic dW5rbm93bi50ZXN0LmR5bnNzaC5za3ljb2RlcjQyLmRlOmo4ZWZ1ODkzcHU4ZnNqaWZza2pmbzk4M3UwZjA5dWZlMHN1ZjA5M3VmOTB1d3U5ZXVzZmtkc2Y=';
     const testKeylessAuthHeader =
-        // ignore: lines_longer_than_80_chars
+        // ignore: lines_longer_than_80_chars for testing
         'Basic a2V5bGVzcy50ZXN0LmR5bnNzaC5za3ljb2RlcjQyLmRlOmo4ZWZ1ODkzcHU4ZnNqaWZza2pmbzk4M3UwZjA5dWZlMHN1ZjA5M3VmOTB1d3U5ZXVzZmtkc2Y=';
 
     late Directory testDir;
@@ -108,7 +108,7 @@ abstract base class DynsshTestCase {
           ReturnCode.values.singleWhere((c) => c.raw == responseBody),
         );
 
-        // ignore: avoid_catches_without_on_clauses
+        // ignore: avoid_catches_without_on_clauses for testing
       } catch (e) {
         printOnFailure(e.toString());
         printOnFailure('RESPONSE: $responseBody');
@@ -232,7 +232,7 @@ abstract base class DynsshTestCase {
   Future<String> getServerIp();
 
   void _printLogRecord(LogRecord logRecord) =>
-      // ignore: avoid_print
+      // ignore: avoid_print for testing
       print('${logRecord.time.toIso8601String()} $logRecord');
 
   String _createSshConfig(String hostName) =>

--- a/test/unit/dynssh/dynssh_controller_test.dart
+++ b/test/unit/dynssh/dynssh_controller_test.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: unnecessary_lambdas
+// ignore_for_file: unnecessary_lambdas for testing
 
 import 'dart:async';
 

--- a/test/unit/ssh/ssh_config_parser_test.dart
+++ b/test/unit/ssh/ssh_config_parser_test.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: unnecessary_lambdas
+// ignore_for_file: unnecessary_lambdas for testing
 
 import 'dart:convert';
 import 'dart:io';

--- a/test/unit/ssh/ssh_known_hosts_parser_test.dart
+++ b/test/unit/ssh/ssh_known_hosts_parser_test.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: unnecessary_lambdas
+// ignore_for_file: unnecessary_lambdas for testing
 
 import 'dart:convert';
 import 'dart:io';


### PR DESCRIPTION
### SDK Updates
- Settings sdk version for dynssh to ^3.10.0
### Dependency Updates
```

Changed 7 constraints in pubspec.yaml:
  dart_test_tools: ^6.2.3+1 -> ^7.0.1
  shelf_api: ^1.4.0 -> ^1.4.1
  build_runner: ^2.9.0 -> ^2.10.4
  dart_pre_commit: ^6.0.0 -> ^6.1.0
  http: ^1.5.0 -> ^1.6.0
  json_serializable: ^6.11.1 -> ^6.11.2
  shelf_api_builder: ^1.3.0 -> ^1.3.1
Resolving dependencies...
Downloading packages...
  _fe_analyzer_shared 91.0.0 (92.0.0 available)
+ analysis_server_plugin 0.3.3 (0.3.4 available)
  analyzer 8.4.0 (9.0.0 available)
  analyzer_buffer 0.1.11 (0.2.0 available)
  analyzer_plugin 0.13.10 (0.13.11 available)
  build_cli 2.2.8 (2.2.9 available)
  characters 1.4.0 (1.4.1 available)
  custom_lint_core 0.8.1 (0.8.2 available)
  custom_lint_visitor 1.0.0+8.4.0 (1.0.0+9.0.0 available)
> dart_test_tools 7.0.1 (was 6.2.3+1)
+ flutter_lints 6.0.0
  freezed 3.2.3 (3.2.4 available)
  json_serializable 6.11.2 (6.11.3 available)
+ lints 6.0.0
  matcher 0.12.17 (0.12.18 available)
  material_color_utilities 0.11.1 (0.13.0 available)
  riverpod 3.0.3 (3.1.0 available)
  riverpod_analyzer_utils 1.0.0-dev.7 (1.0.0-dev.8 available)
  riverpod_annotation 3.0.3 (4.0.0 available)
  riverpod_generator 3.0.3 (4.0.0+1 available)
  riverpod_lint 3.0.3 (3.1.0 available)
  source_helper 1.3.8 (1.3.9 available)
  test 1.26.3 (1.28.0 available)
  test_api 0.7.7 (0.7.8 available)
  test_core 0.6.12 (0.6.14 available)
Changed 4 dependencies!
22 packages have newer versions incompatible with dependency constraints.
Try `flutter pub outdated` for more information.
```
