### PR TITLE
Automatic dependency updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.4] - 2026-02-19
+### Changed
+- Updated min sdk version to ^3.11.0
+- Updated dependencies
+
 ## [1.1.3] - 2026-01-01
 ### Changed
 - Updated min sdk version to ^3.10.0
@@ -79,6 +84,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial pre-release
 
+[1.1.4]: https://github.com/Skycoder42/dynssh/compare/v1.1.3...v1.1.4
 [1.1.3]: https://github.com/Skycoder42/dynssh/compare/v1.1.2...v1.1.3
 [1.1.2]: https://github.com/Skycoder42/dynssh/compare/v1.1.1...v1.1.2
 [1.1.1]: https://github.com/Skycoder42/dynssh/compare/v1.1.0...v1.1.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,10 +1,10 @@
 name: dynssh
 description: A small server utility to dynamically update the SSH configuration for a remote host with dynamic IPs.
-version: 1.1.3
+version: 1.1.4
 publish_to: none
 
 environment:
-  sdk: ^3.10.0
+  sdk: ^3.11.0
 
 platforms:
   linux:
@@ -18,29 +18,29 @@ dependencies:
   build_cli_annotations: ^2.1.1
   collection: ^1.19.1
   freezed_annotation: ^3.1.0
-  json_annotation: ^4.9.0
+  json_annotation: ^4.10.0
   logging: ^1.3.0
   meta: ^1.17.0
   posix: ^6.0.3
-  riverpod: ^3.0.3
-  riverpod_annotation: ^3.0.3
+  riverpod: ^3.2.1
+  riverpod_annotation: ^4.0.2
   shelf: ^1.4.2
-  shelf_api: ^1.4.1
+  shelf_api: ^1.4.2
   synchronized: ^3.4.0
 
 dev_dependencies:
-  build_cli: ^2.2.8
-  build_runner: ^2.10.4
+  build_cli: ^2.2.10
+  build_runner: ^2.11.1
   dart_pre_commit: ^6.1.0
   dart_test_tools: ^7.0.1
-  freezed: ^3.2.3
+  freezed: ^3.2.5
   http: ^1.6.0
-  json_serializable: ^6.11.2
+  json_serializable: ^6.12.0
   mocktail: ^1.0.4
-  riverpod_generator: ^3.0.3
-  riverpod_lint: ^3.0.3
-  shelf_api_builder: ^1.3.1
-  test: ^1.28.0
+  riverpod_generator: ^4.0.3
+  riverpod_lint: ^3.1.3
+  shelf_api_builder: ^1.3.2
+  test: ^1.29.0
 
 dart_pre_commit:
   flutter-compat: false


### PR DESCRIPTION
### SDK Updates
- Settings sdk version for dynssh to ^3.11.0
### Dependency Updates
```

Changed 12 constraints in pubspec.yaml:
  riverpod_annotation: ^3.0.3 -> ^4.0.2
  riverpod_generator: ^3.0.3 -> ^4.0.3
  json_annotation: ^4.9.0 -> ^4.10.0
  riverpod: ^3.0.3 -> ^3.2.1
  shelf_api: ^1.4.1 -> ^1.4.2
  build_cli: ^2.2.8 -> ^2.2.10
  build_runner: ^2.10.4 -> ^2.11.1
  freezed: ^3.2.3 -> ^3.2.5
  json_serializable: ^6.11.2 -> ^6.12.0
  riverpod_lint: ^3.0.3 -> ^3.1.3
  shelf_api_builder: ^1.3.1 -> ^1.3.2
  test: ^1.28.0 -> ^1.29.0
Resolving dependencies...
Downloading packages...
> _fe_analyzer_shared 92.0.0 (was 91.0.0) (95.0.0 available)
> analysis_server_plugin 0.3.4 (was 0.3.3) (0.3.9 available)
> analyzer 9.0.0 (was 8.4.0) (10.1.0 available)
> analyzer_buffer 0.3.0 (was 0.1.11) (0.3.1 available)
> analyzer_plugin 0.13.11 (was 0.13.10) (0.14.3 available)
> build_cli 2.2.10 (was 2.2.8)
  dart_style 3.1.3 (3.1.5 available)
> freezed 3.2.5 (was 3.2.3)
> json_annotation 4.10.0 (was 4.9.0)
+ json_schema 5.2.2
> json_serializable 6.12.0 (was 6.11.2)
  meta 1.17.0 (1.18.1 available)
+ quiver 3.2.2
> riverpod 3.2.1 (was 3.0.3)
> riverpod_analyzer_utils 1.0.0-dev.9 (was 1.0.0-dev.7)
> riverpod_annotation 4.0.2 (was 3.0.3)
> riverpod_generator 4.0.3 (was 3.0.3)
> riverpod_lint 3.1.3 (was 3.0.3)
> shelf_api 1.4.2 (was 1.4.1)
> shelf_api_builder 1.3.2 (was 1.3.1)
> source_helper 1.3.10 (was 1.3.8)
+ uri 1.0.0
These packages are no longer being depended on:
- ci 0.1.0
- cli_util 0.4.2
- custom_lint 0.8.1
- custom_lint_builder 0.8.1
- custom_lint_core 0.8.1
- custom_lint_visitor 1.0.0+8.4.0
- hotreloader 4.3.0
- uuid 4.5.2
Changed 28 dependencies!
7 packages have newer versions incompatible with dependency constraints.
Try `flutter pub outdated` for more information.
```
